### PR TITLE
Improved Linux support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,8 @@ check-variables:
 
 engine-dependencies: check-variables check-sdk-scripts
 	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
-	@cd $(ENGINE_DIRECTORY) && make dependencies WIN32=$(WIN32)
 
-engine: check-variables check-sdk-scripts
-	@./fetch-engine.sh || (printf "Unable to continue without engine files\n"; exit 1)
+engine: engine-dependencies check-variables check-sdk-scripts
 	@cd $(ENGINE_DIRECTORY) && make core WIN32=$(WIN32)
 
 utility: engine-dependencies engine


### PR DESCRIPTION
`make dependencies` currently fails due to engine changes.